### PR TITLE
Create swampwater.recipe

### DIFF
--- a/recipes/chemlab/liquids/swampwater.recipe
+++ b/recipes/chemlab/liquids/swampwater.recipe
@@ -1,0 +1,13 @@
+{
+  "input" : [
+    { "item" : "liquidwater", "count" : 3 },
+    { "item" : "algaegreen", "count" : 2 },
+    { "item" : "mud", "count" : 1 }
+  ],
+  "output" : {
+    "item" : "swampwater",
+    "count" : 3
+  },
+  "groups" : [ "chemlab1", "liquids", "all","nouncrafting","norecycling" ],
+  "duration" : 0.25
+}

--- a/zb/researchTree/fu_chemistry.config
+++ b/zb/researchTree/fu_chemistry.config
@@ -155,7 +155,7 @@
         "position" : [40, -35],
         "children" : [ "liquidcrafting2", "mechfuel" ],
         "price" : [["fuscienceresource", 350], ["liquidwater", 50], ["fu_hydrogen", 15]],
-        "unlocks" : [ "cellmateria", "liquidblacktar", "liquidpoison", "liquidwater", "fusaltwater", "liquidpus", "waterball" ]
+        "unlocks" : [ "cellmateria", "liquidblacktar", "liquidpoison", "liquidwater", "fusaltwater", "liquidpus", "swampwater", "waterball" ]
       },
       "liquidcrafting2" : {
         "icon" : "/items/liquids/ff_mercury.png",


### PR DESCRIPTION
Iron Cent costs 4w, Industrial costs 12w. So you can power 3 irons per industrial.
Here's an example using Lava, the best case scenario for Industrial as it is nearly unlimited for centrifuging purposes.
Iron: 3.53 per second
Industrial: 5 per second

| Material          | Odds  | Results per Second |
|-------------------|-------|--------------------|
| Corefrag(iron)    | 10%   |  0.353 (winner)    | 
| ironore (iron)    | 4.5%  |  0.159             |
| copper (iron)     | 4.5%  |  0.159             |
| Carbon (iron)     | 0.8%  |  0.028             |
| Silicon (iron)    | 1.5%  |  0.053  (winner)   |
| Tungsten(iron)    | 1.5%  |  0.053  (winner)   |
|===================|=======|====================|
| Corefrag(indust)  | 6.67% |  0.334             |
| ironore (indust)  | 3.5%  |  0.175 (winner)    |
| copper (indust)   | 3.5%  |	 0.175 (winner)    |
| Carbon (indust)   | 0.7%  |  0.035 (winner)    |
| Silicon (indust)  | 1%    |  0.05	             |
| Tungsten(indust)  | 1%    |  0.05              |